### PR TITLE
Switched network tier to PREMIUM instead of STANDARD

### DIFF
--- a/compute.tf
+++ b/compute.tf
@@ -16,7 +16,7 @@ resource "google_compute_instance" "postgresql" {
   network_interface {
     network = "default"
     access_config {
-      network_tier = "STANDARD"
+      network_tier = "PREMIUM" // Free tier uses on PREMIUM network tier
     }
   }
 


### PR DESCRIPTION
## What was done

- As it turns out, free tier uses `PREMIUM` network tier instead of `STANDARD` as per https://cloud.google.com/network-tiers/pricing
